### PR TITLE
buffer_read_bytes() renamed to buffer_read_bytes_with_size() to avoid collisions with the SDK

### DIFF
--- a/src/buffer_util.c
+++ b/src/buffer_util.c
@@ -17,7 +17,7 @@ static uint32_t min(uint32_t a, uint32_t b) {
  *
  * Returns the number of bytes read.
  */
-size_t buffer_read_bytes(buffer_t *buffer, uint8_t *out, size_t out_len) {
+size_t buffer_read_bytes_with_size(buffer_t *buffer, uint8_t *out, size_t out_len) {
     // Choose an amount to read that cannot overflow unless it is already
     // overflown
     size_t amount_read = min(out_len, buffer->size - buffer->offset);

--- a/src/buffer_util.h
+++ b/src/buffer_util.h
@@ -7,7 +7,7 @@
  * Reads as many bytes as possible from the buffer, but at most out_len.
  * Returns the number of bytes read.
  */
-size_t buffer_read_bytes(buffer_t *buffer, uint8_t *out, size_t out_len);
+size_t buffer_read_bytes_with_size(buffer_t *buffer, uint8_t *out, size_t out_len);
 
 /**
  * Reads out_len bytes to the out buffer

--- a/src/transaction/deserialize.c
+++ b/src/transaction/deserialize.c
@@ -114,7 +114,7 @@ static parser_status_e parse_rpc_mpc_token(buffer_t *chunk, transaction_t *tx) {
         }
 
         // Read long memo
-        size_t read_bytes = buffer_read_bytes(chunk, tx->mpc_transfer.memo, memo_length);
+        size_t read_bytes = buffer_read_bytes_with_size(chunk, tx->mpc_transfer.memo, memo_length);
 
         // Check that the entire memo was read, and not just a part (such that
         // the rest of the memo is on the next chunk.)

--- a/unit-tests/test_tx_parser.c
+++ b/unit-tests/test_tx_parser.c
@@ -737,7 +737,7 @@ static void test_buffer_read_bytes_out_longer(void **state) {
     buffer_t buf = {.ptr = raw_buffer, .size = sizeof(raw_buffer), .offset = 0};
 
     uint8_t out_buffer[20];
-    size_t amount_read = buffer_read_bytes(&buf, out_buffer, sizeof(out_buffer));
+    size_t amount_read = buffer_read_bytes_with_size(&buf, out_buffer, sizeof(out_buffer));
     assert_int_equal(amount_read, 10);
 }
 
@@ -748,7 +748,7 @@ static void test_buffer_read_bytes_in_longer(void **state) {
     buffer_t buf = {.ptr = raw_buffer, .size = sizeof(raw_buffer), .offset = 0};
 
     uint8_t out_buffer[10];
-    size_t amount_read = buffer_read_bytes(&buf, out_buffer, sizeof(out_buffer));
+    size_t amount_read = buffer_read_bytes_with_size(&buf, out_buffer, sizeof(out_buffer));
     assert_int_equal(amount_read, 10);
 }
 
@@ -757,7 +757,7 @@ static void test_buffer_variant_read_with_offset(size_t offset, size_t expected_
     buffer_t buf = {.ptr = raw_buffer, .size = sizeof(raw_buffer), .offset = offset};
 
     uint8_t out_buffer[10];
-    size_t amount_read = buffer_read_bytes(&buf, out_buffer, sizeof(out_buffer));
+    size_t amount_read = buffer_read_bytes_with_size(&buf, out_buffer, sizeof(out_buffer));
     assert_int_equal(amount_read, expected_read);
 }
 


### PR DESCRIPTION
**The goal is to fix "Build all C apps on latest C SDK" in https://github.com/LedgerHQ/ledger-secure-sdk/pull/1419/ **


# Checklist
<!-- Put an `x` in each box when you have completed the items. -->
- [ ] App update process has been followed <!-- See comment below -->
- [ ] Target branch is `develop` <!-- unless you have a very good reason -->
- [ ] Application version has been bumped <!-- required if your changes are to be deployed -->

<!-- Make sure you followed the process described in https://developers.ledger.com/docs/embedded-app/maintenance/ before opening your Pull Request.
Don't hesitate to contact us directly on Discord if you have any questions ! https://developers.ledger.com/discord -->
